### PR TITLE
Remove RU-RTK-20070321 from gov netnames

### DIFF
--- a/lists/ru-gov-netnames.txt
+++ b/lists/ru-gov-netnames.txt
@@ -944,11 +944,6 @@ netname: RU-RUSCOMNET-20030515
 ######### РКН-related #########
 ###############################
 
-netname: RU-RTK-20070321
-# org: ORG-JR8-RIPE
-# descr: NCNET
-# origin: AS42610
-
 # name: server referenced as "oldip" in DNS of 1whois
 netname: STARNET-VPN
 # descr: ISP "Starnet" - Home LAN's in Moscow


### PR DESCRIPTION
It is used for residential addresses too.

Example: https://hubzil.la/ has IP 77.37.174.66