### PR TITLE
fix: avoid matching TVK-AS with the VK-AS blacklist pattern

### DIFF
--- a/blacklists_updater_common.subr
+++ b/blacklists_updater_common.subr
@@ -26,7 +26,8 @@ NETWORK_LIST_FROM_AS="${SCRIPT_DIR}/network_list_from_as.py"
 NETWORK_LIST_FROM_NETNAME="${SCRIPT_DIR}/network_list_from_netname.py"
 RU_GOV_NETNAMES_FILE="${SCRIPT_DIR}/lists/ru-gov-netnames.txt"
 
-BLACK_NAMES='uvd|umvd|fgup|grchc|roskomnad|federalnaya sluzhba|ufsb|zonatelecom|llc vk|vkontakte|ODNOKLASSNIKI|VKCOMPANY|mail.ru|mail-ru|mail_ru|VK-AS|M100'
+# Match VK-AS as a complete name to avoid unrelated names such as TVK-AS.
+BLACK_NAMES='uvd|umvd|fgup|grchc|roskomnad|federalnaya sluzhba|ufsb|zonatelecom|llc vk|vkontakte|ODNOKLASSNIKI|VKCOMPANY|mail.ru|mail-ru|mail_ru|(^|[^[:alnum:]_-])VK-AS([^[:alnum:]_-]|$)|M100'
 WHITE_NAMES='ruvds'
 #VK_NAME_PATTERN='ru-netbridge-(19911202|20061117)|ru-odnoklassniki-(20100830|20120307|20120626)|odnoklassniki-front'
 #VK_NAME_PATTERN='ru-netbridge-(19911202|20061117)|odnoklassniki'

--- a/tests/test_blacklist_name_matching.py
+++ b/tests/test_blacklist_name_matching.py
@@ -1,0 +1,60 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class BlacklistNameMatchingTests(unittest.TestCase):
+    def assert_name_match(self, record, expected):
+        result = subprocess.run(
+            [
+                "sh",
+                "-c",
+                'SCRIPT_DIR=.; . ./blacklists_updater_common.subr; grep -iE "$BLACK_NAMES"',
+            ],
+            input=record + "\n",
+            text=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        self.assertIn(result.returncode, (0, 1), result.stderr)
+        self.assertEqual(result.returncode == 0, expected, record)
+
+    def test_vk_as_matches_as_a_complete_name(self):
+        for record in (
+            "AS64512 VK-AS (Example Network)",
+            "AS64512 vk-as (Example Network)",
+            "VK-AS",
+            "AS64512 VK-AS",
+            "(VK-AS)",
+        ):
+            with self.subTest(record=record):
+                self.assert_name_match(record, True)
+
+    def test_vk_as_does_not_match_inside_other_names(self):
+        for record in (
+            "AS43720 TVK-AS (MTS OJSC)",
+            "AS43038 TVK-AS (MTS PJSC)",
+            "AS64512 OTHER-VK-AS (Example Network)",
+            "AS64512 VK-AS-OTHER (Example Network)",
+            "AS64512 VK-AS_OTHER (Example Network)",
+            "AS64512 VK-AS123 (Example Network)",
+        ):
+            with self.subTest(record=record):
+                self.assert_name_match(record, False)
+
+    def test_other_blacklist_terms_still_match(self):
+        for record in (
+            "AS47764 VK-AS (LLC VK)",
+            "AS64512 TVK-AS (FGUP Example)",
+            "AS64512 VKONTAKTE-SPB-AS (Example Network)",
+        ):
+            with self.subTest(record=record):
+                self.assert_name_match(record, True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `VK-AS` alternative in `BLACK_NAMES` also matches `TVK-AS`. This selects the MTS records `AS43038 TVK-AS (MTS PJSC)` and `AS43720 TVK-AS (MTS OJSC)` and includes their announced networks in the general blacklist, affecting residential subscribers.

Match `VK-AS` as a complete name using POSIX character classes. Add regression tests that exercise the shared configuration through `sh` and `grep -iE`, covering the two MTS records, case-insensitive exact matches, name boundaries, and independent blacklist terms.

Validation:

- `python -m unittest discover -s tests -v`: all 7 tests pass, including 3 new tests with 14 cases.
- The new negative cases reproduce the false positive on the original rule.
- `sh -n blacklists_updater_common.subr` and `git diff --check` pass.
- Comparing the old and new selectors against the checked-in source data removes only AS43038 and AS43720 from the ASN selection. IPv4 source selections are unchanged.

Generated blacklists are left to the existing update workflow after merge. This PR fixes the generator; it does not immediately change the published lists. No subscriber IP addresses or connection logs are included.
